### PR TITLE
fixes link to underthehood.meltwater.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ _Immutable Web Applications_ methodology builds on several trends in web applica
 
 - [_"Single-page App Deployments"_](https://www.meetup.com/nh-js-manchester/events/255671618/), Gene Connolly, [NH.js](https://www.meetup.com/nh-js-manchester/), November 14th 2018
 
-- [_"Risk-free Deployments with Immutable Web Apps"_](https://underthehood.meltwater.com/blog/2018/12/03/risk-free-deployments-with-immutable-web-apps/), Gene Connolly, [underthehood.meltwater.com], December 3rd 2018
+- [_"Risk-free Deployments with Immutable Web Apps"_](https://underthehood.meltwater.com/blog/2018/12/03/risk-free-deployments-with-immutable-web-apps/), Gene Connolly, [underthehood.meltwater.com](https://underthehood.meltwater.com), December 3rd 2018
 
 ## ![Future Work](icons/favicon-16x16.png) Future Work
 


### PR DESCRIPTION
The markdown with what was probably meant as a link to underthehood.meltwater.com was broken.
I fixed this link.