### PR TITLE
Correct URL for Create React App's environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Static assets are the files (javascript, css, images) that are generated from a 
 
 #### Static assets must not contain anything that is environment-specific
 
-All of the leading application frameworks ([Angular CLI](https://github.com/angular/angular-cli/wiki/stories-application-environments), [Create React App](https://cli.vuejs.org/guide/mode-and-env.html#using-env-variables-in-client-side-code), [Ember CLI](https://ember-cli.com/user-guide/#Environments), [Vue CLI 3](https://cli.vuejs.org/guide/mode-and-env.html#using-env-variables-in-client-side-code)) recommend defining environment _values_ at _compile time_. This practice requires that the static assets are generated for each environment and regenerated for any change to an environment.
+All of the leading application frameworks ([Angular CLI](https://github.com/angular/angular-cli/wiki/stories-application-environments), [Create React App](https://facebook.github.io/create-react-app/docs/adding-custom-environment-variables), [Ember CLI](https://ember-cli.com/user-guide/#Environments), [Vue CLI 3](https://cli.vuejs.org/guide/mode-and-env.html#using-env-variables-in-client-side-code)) recommend defining environment _values_ at _compile time_. This practice requires that the static assets are generated for each environment and regenerated for any change to an environment.
 
 _Immutable Web Applications_ reference environment _variables_ that are defined on the global scope and reference one of two ways:
 


### PR DESCRIPTION
Previously it was linking to Vue CLI's environment variable documentation. Now it links to https://facebook.github.io/create-react-app/docs/adding-custom-environment-variables.